### PR TITLE
Fix import path for eris

### DIFF
--- a/irc/serv.go
+++ b/irc/serv.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/mmcloughlin/professor"
-	"github.com/prologic/eris/irc"
+	"git.mills.io/prologic/eris/irc"
 	"github.com/sethvargo/go-password/password"
 	"golang.org/x/crypto/bcrypt"
 )


### PR DESCRIPTION
Fix import path for eris

Project has moved to [git.mills.io/prologic/eris](https://git.mills.io/prologic/eris).

For details on why see: https://github.com/prologic

Thank you! 🙇
